### PR TITLE
Adding zlib and libjpeg to docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM nginx:latest
 RUN apt-get update -y
 RUN apt-get upgrade -y
-RUN apt-get install python3 python3-pip python3-venv -y
+RUN apt-get install python3 python3-pip python3-venv zlib1g-dev libjpeg-dev -y
 RUN mkdir export
 RUN ln -s /export /usr/share/nginx/html/export
 COPY requirements.txt .


### PR DESCRIPTION
What the title says, adding zlib and libjpeg to the docker image since these are missing from `nginx:latest`.  